### PR TITLE
feat: Implement switchable aircraft symbols

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -44,6 +44,7 @@
         <label><input type="checkbox" id="radarToggle" checked> Tampilkan Radar (250 km)</label>
 		<label><input type="checkbox" id="sweepToggle" checked> Animasi Sweep Radar</label>
 	    <label><input type="checkbox" id="multiSelectToggle"> Multi Select</label>
+        <label><input type="checkbox" id="symbolModeToggle"> Ubah Simbol (Vector)</label>
 
         <div id="timescale-controls" style="margin-top: 8px;">
             <label>Sim Speed:</label>
@@ -374,11 +375,12 @@ document.addEventListener('mouseup', (e) => {
 	  y: relY,
 	  width: rect.width,
 	  height: rect.height,
-	  layerIds: ['planes-layer']
+	  layerIds: symbolModeVector ? ['plane-squares'] : ['planes-layer']
 	});
 
 
     selectedPlaneIds = picked.map(p => p.object.id);
+    refreshLayers(); // panggil refresh untuk update highlight
 
     if (selectedPlaneIds.length > 0) {
         showGroupCommandForm(e.clientX, e.clientY);
@@ -457,6 +459,48 @@ document.addEventListener('mouseup', (e) => {
     // Pastikan iconAtlas/iconMapping media tersedia
     // --------------------------
     let currentPlanes = [];
+    let symbolModeVector = false; // state untuk mode simbol
+
+    // event listener untuk toggle simbol
+    document.getElementById('symbolModeToggle').addEventListener('change', (e) => {
+        symbolModeVector = e.target.checked;
+        refreshLayers(); // render ulang untuk ganti simbol
+    });
+
+    // Helper untuk membuat ikon kotak secara dinamis
+    function createSquareIcon(size, color) {
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, size, size);
+        return canvas;
+    }
+
+    const SQUARE_ICON_ATLAS = createSquareIcon(64, 'yellow');
+    const SQUARE_ICON_MAPPING = {
+        square: { x: 0, y: 0, width: 64, height: 64, mask: true }
+    };
+
+
+    // Handler event untuk interaksi plane (menghindari duplikasi)
+    function planeOnHover({ object, x, y }) {
+        if (object) {
+            tooltipEl.style.left = x + 'px';
+            tooltipEl.style.top = y + 'px';
+            tooltipEl.innerHTML = `ID: ${object.id || 'N/A'}<br>Lat: ${object.lat}<br>Lon: ${object.lon}<br>heading: ${object.heading || 0}`;
+            tooltipEl.style.display = 'block';
+        } else {
+            tooltipEl.style.display = 'none';
+        }
+    }
+
+    function planeOnClick({ object, x, y }) {
+        if (object) {
+            showCommandForm(object, x, y);
+        }
+    }
 
     // gunakan iconAtlas default (bisa diganti)
     const ICON_ATLAS = 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.png';
@@ -607,37 +651,52 @@ if (showRadars && radarPolygons.length > 0) {
 
         // Plane IconLayer (same gaya seperti sebelumnya)
         if (currentPlanes && currentPlanes.length > 0) {
-		const iconLayer = new deck.IconLayer({
-			id: 'planes-layer',
-			data: currentPlanes,
-			iconAtlas: ICON_ATLAS,
-			iconMapping: ICON_MAPPING,
-			getIcon: d => 'plane',
-			getPosition: d => [d.lon, d.lat, d.alt || 0],
-			getSize: d => 40,
-			sizeScale: 1,
-			sizeMinPixels: 20,
-			sizeMaxPixels: 60,
+            if (symbolModeVector) {
+                // Mode 2: Bujur sangkar (IconLayer) + Vektor kecepatan
+                const planeSquares = new deck.IconLayer({
+                    id: 'plane-squares',
+                    data: currentPlanes,
+                    iconAtlas: SQUARE_ICON_ATLAS,
+                    iconMapping: SQUARE_ICON_MAPPING,
+                    getIcon: d => 'square',
+                    getPosition: d => [d.lon, d.lat, d.alt || 0],
+                    getSize: 12,
+                    sizeScale: 1,
+                    pickable: true,
+                    onHover: planeOnHover,
+                    onClick: planeOnClick,
+                });
 
-			pickable: true,
-			onHover: ({ object, x, y }) => {
-				if (object) {
-					tooltipEl.style.left = x + 'px';
-					tooltipEl.style.top = y + 'px';
-					tooltipEl.innerHTML = `ID: ${object.id || 'N/A'}<br>Lat: ${object.lat}<br>Lon: ${object.lon}<br>heading: ${object.heading || 0}`;
-					tooltipEl.style.display = 'block';
-				} else {
-					tooltipEl.style.display = 'none';
-				}
-			},
-			onClick: ({ object, x, y }) => {
-				if (object) {
-					showCommandForm(object, x, y);
-				}
-			}
-		});
-
-            layers.push(iconLayer);
+                const speedVectors = new deck.LineLayer({
+                    id: 'speed-vectors',
+                    data: currentPlanes,
+                    getSourcePosition: d => [d.lon, d.lat, d.alt || 0],
+                    getTargetPosition: d => destinationPoint(d.lat, d.lon, d.heading, (d.speed || 0) * 0.02), // panjang vektor
+                    getColor: [255, 255, 0, 255],
+                    getWidth: 2,
+                    widthUnits: 'pixels',
+                });
+                layers.push(planeSquares, speedVectors);
+            } else {
+                // Mode 1: Simbol pesawat berputar
+                const iconLayer = new deck.IconLayer({
+                    id: 'planes-layer',
+                    data: currentPlanes,
+                    iconAtlas: ICON_ATLAS,
+                    iconMapping: ICON_MAPPING,
+                    getIcon: d => 'plane',
+                    getPosition: d => [d.lon, d.lat, d.alt || 0],
+                    getSize: d => 40,
+                    getAngle: d => -(d.heading || 0), // Rotasi berdasarkan heading (berlawanan arah jarum jam)
+                    sizeScale: 1,
+                    sizeMinPixels: 20,
+                    sizeMaxPixels: 60,
+                    pickable: true,
+                    onHover: planeOnHover,
+                    onClick: planeOnClick,
+                });
+                layers.push(iconLayer);
+            }
 			if (selectedPlaneId !== null) {
 				const selectedData = currentPlanes.filter(p => p.id === selectedPlaneId);
 				if (selectedData.length > 0) {


### PR DESCRIPTION
This commit introduces a new feature allowing users to switch between two different visualizations for aircraft on the map:

1.  A traditional airplane icon that rotates to match the aircraft's heading.
2.  A square marker with a speed vector line, where the line's direction indicates heading and its length is proportional to speed.

A checkbox control has been added to the UI to toggle between these two modes.

The implementation uses deck.gl layers:
- The airplane icon is an `IconLayer` with its `getAngle` property set to the inverse of the heading to match deck.gl's counter-clockwise rotation.
- The square marker is also an `IconLayer`, using a dynamically generated canvas element as its icon atlas to ensure a constant pixel size across all zoom levels.
- The speed vector is a `LineLayer` with its target calculated using the aircraft's speed and heading.

Event handlers for hover and click have been refactored into common functions to improve maintainability, and the multi-select feature has been updated to be compatible with both symbol modes.